### PR TITLE
Cleanup of redundant fields

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
       - id: requirements-txt-fixer
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.11.8
+    rev: v0.11.9
     hooks:
       # Run the linter.
       - id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "setuptools>=45", "wheel" ]
 
 [project]
 name = "docstring2json"
-version = "0.0.9"
+version = "0.0.10"
 description = "A tool to convert Google-style docstrings to JSON format"
 readme = "README.md"
 keywords = [

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -176,7 +176,6 @@ def test_class_to_data_basic_fields(test_obj: Any, expected_fields: dict[str, An
 
     # Check all required fields exist
     assert "signature" in result
-    assert "source_line" in result
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary by Sourcery

Remove unused and redundant fields and type aliases from the converter module, and update dependencies and versioning.

Enhancements:
- Remove unused constants, type aliases, and the get_source_line function from the converter module.
- Simplify function signatures and data structures in the converter module.

Build:
- Update ruff pre-commit hook to v0.11.9.
- Bump project version to 0.0.10 in pyproject.toml.

Tests:
- Remove test assertion for the deleted 'source_line' field in class_to_data output.